### PR TITLE
feat: Implement A&R Discovery feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const ReleaseManagerPage = lazyLoad(() => import('./pages/ReleaseManagerPage'));
 const RoyaltyTrackerPage = lazyLoad(() => import('./pages/RoyaltyTrackerPage'));
 const SocialAnalyticsPage = lazyLoad(() => import('./pages/SocialAnalyticsPage'));
 const ISRCManagerPage = lazyLoad(() => import('./pages/ISRCManagerPage'));
+const ARDiscoveryPage = lazyLoad(() => import('./pages/ARDiscoveryPage'));
 
 function App() {
   return (
@@ -103,6 +104,12 @@ function App() {
                 >
                   ISRC Manager
                 </Link>
+                <Link
+                  to="/ar/discover"
+                  className="text-light-text-secondary dark:text-dark-text-secondary hover:text-accent-primary px-3 py-2 rounded-md text-sm font-medium"
+                >
+                  A&R Discovery
+                </Link>
               </div>
             </div>
           </div>
@@ -123,6 +130,7 @@ function App() {
             <Route path="/analytics" element={<SocialAnalyticsPage />} />
             <Route path="/releases" element={<ReleaseManagerPage />} />
             <Route path="/isrc" element={<ISRCManagerPage />} />
+            <Route path="/ar/discover" element={<ARDiscoveryPage />} />
           </Routes>
         </main>
       </div>

--- a/src/components/specific/PreviewPanel.tsx
+++ b/src/components/specific/PreviewPanel.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Prospect } from './ResultsGrid';
+import { FaTimes } from 'react-icons/fa';
+import { useARDiscoverStore } from '../../store/arDiscoverStore';
+
+interface PreviewPanelProps {
+  prospect: Prospect | null;
+  onClose: () => void;
+  onSave: (prospect: Prospect) => void;
+}
+
+const PreviewPanel: React.FC<PreviewPanelProps> = ({ prospect, onClose, onSave }) => {
+  const { highlightUrl, loading } = useARDiscoverStore();
+
+  if (!prospect) {
+    return null;
+  }
+
+  return (
+    <div className="fixed top-0 right-0 h-full w-full md:w-1/3 bg-light-surface dark:bg-dark-surface shadow-lg p-6 overflow-y-auto transform transition-transform duration-300 ease-in-out"
+         style={{ transform: prospect ? 'translateX(0)' : 'translateX(100%)' }}>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-bold">Preview</h2>
+        <button onClick={onClose} className="text-light-text-secondary dark:text-dark-text-secondary">
+          <FaTimes />
+        </button>
+      </div>
+      <div>
+        <img src={prospect.imageUrl} alt={prospect.trackTitle} className="w-full h-64 object-cover rounded-md mb-4" />
+        <h3 className="text-2xl font-bold">{prospect.trackTitle}</h3>
+        <p className="text-lg text-light-text-secondary dark:text-dark-text-secondary mb-4">{prospect.artistName}</p>
+        <div className="mb-4">
+          <h4 className="font-bold mb-2">Why Surfaced</h4>
+          <div className="flex flex-wrap gap-2">
+            {prospect.reasons.map((reason, index) => (
+              <span key={index} className="px-2 py-1 bg-accent-primary-light text-accent-primary-dark text-xs rounded-full">
+                {reason}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h4 className="font-bold mb-2">Audio Highlight</h4>
+          {loading && !highlightUrl ? <p>Loading highlight...</p> : null}
+          {highlightUrl && (
+            <audio controls src={highlightUrl} className="w-full">
+              Your browser does not support the audio element.
+            </audio>
+          )}
+        </div>
+        <div className="mt-4">
+            <h4 className="font-bold mb-2">Notes</h4>
+            <textarea
+                className="w-full p-2 bg-light-background dark:bg-dark-background border border-light-divider dark:border-dark-divider rounded-md"
+                placeholder="Add notes here..."
+            ></textarea>
+        </div>
+        <div className="mt-6 flex justify-end">
+          <button
+            onClick={() => onSave(prospect)}
+            className="px-4 py-2 bg-accent-primary text-white rounded-md hover:bg-accent-primary-dark"
+          >
+            Save Prospect
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PreviewPanel;

--- a/src/components/specific/ResultsGrid.tsx
+++ b/src/components/specific/ResultsGrid.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface Prospect {
+  id: string;
+  artistName: string;
+  trackTitle: string;
+  imageUrl: string;
+  reasons: string[];
+}
+
+interface ResultsGridProps {
+  prospects: Prospect[];
+  onSelectProspect: (prospect: Prospect) => void;
+}
+
+const ResultsGrid: React.FC<ResultsGridProps> = ({ prospects, onSelectProspect }) => {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      {prospects.map((prospect) => (
+        <div
+          key={prospect.id}
+          className="bg-light-surface dark:bg-dark-surface rounded-lg shadow-md p-4 cursor-pointer hover:shadow-lg transition-shadow"
+          onClick={() => onSelectProspect(prospect)}
+        >
+          <div className="relative">
+            <img src={prospect.imageUrl} alt={prospect.trackTitle} className="w-full h-48 object-cover rounded-md mb-4" />
+          </div>
+          <h3 className="text-lg font-bold truncate">{prospect.trackTitle}</h3>
+          <p className="text-sm text-light-text-secondary dark:text-dark-text-secondary">{prospect.artistName}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {prospect.reasons.map((reason, index) => (
+              <span key={index} className="px-2 py-1 bg-accent-primary-light text-accent-primary-dark text-xs rounded-full">
+                {reason}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ResultsGrid;

--- a/src/pages/ARDiscoveryPage.test.tsx
+++ b/src/pages/ARDiscoveryPage.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ARDiscoveryPage from './ARDiscoveryPage';
+import { useARDiscoverStore } from '../store/arDiscoverStore';
+import React from 'react';
+
+// Mock the store
+vi.mock('../store/arDiscoverStore');
+
+const mockStore = {
+  filters: { growth: '', saves: '', shares: '' },
+  prospects: [
+    { id: '1', artistName: 'Artist One', trackTitle: 'Track A', imageUrl: 'https://via.placeholder.com/150', reasons: ['High Growth'] },
+  ],
+  savedProspects: [],
+  selectedProspect: null,
+  loading: false,
+  highlightUrl: null,
+  setFilters: vi.fn(),
+  searchProspects: vi.fn(),
+  exportProspects: vi.fn(),
+  selectProspect: vi.fn(),
+  addToSaved: vi.fn(),
+  getHighlight: vi.fn(),
+};
+
+describe('ARDiscoveryPage', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks();
+    (useARDiscoverStore as any).mockReturnValue(mockStore);
+  });
+
+  it('renders the page title', () => {
+    render(<ARDiscoveryPage />);
+    expect(screen.getByText('A&R Discovery')).toBeInTheDocument();
+  });
+
+  it('calls searchProspects on initial render', () => {
+    render(<ARDiscoveryPage />);
+    expect(mockStore.searchProspects).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates filters on input change', () => {
+    render(<ARDiscoveryPage />);
+    const growthInput = screen.getByLabelText('Growth Rate');
+    fireEvent.change(growthInput, { target: { name: 'growth', value: '90' } });
+    expect(mockStore.setFilters).toHaveBeenCalledWith({ growth: '90' });
+  });
+
+  it('calls searchProspects when apply button is clicked', () => {
+    render(<ARDiscoveryPage />);
+    const applyButton = screen.getByText('Apply');
+    fireEvent.click(applyButton);
+    // The first call is from useEffect
+    expect(mockStore.searchProspects).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders the results grid with prospects', () => {
+    render(<ARDiscoveryPage />);
+    expect(screen.getByText('Track A')).toBeInTheDocument();
+  });
+
+  it('calls selectProspect when a prospect is clicked', () => {
+    render(<ARDiscoveryPage />);
+    const prospectCard = screen.getByText('Track A');
+    fireEvent.click(prospectCard);
+    expect(mockStore.selectProspect).toHaveBeenCalledWith(mockStore.prospects[0]);
+  });
+
+  it('shows the preview panel when a prospect is selected', () => {
+    (useARDiscoverStore as any).mockReturnValue({
+      ...mockStore,
+      selectedProspect: mockStore.prospects[0],
+    });
+    render(<ARDiscoveryPage />);
+    expect(screen.getByText('Preview')).toBeInTheDocument();
+    expect(screen.getByText('Save Prospect')).toBeInTheDocument();
+  });
+
+  it('calls addToSaved when save button is clicked in preview', () => {
+    (useARDiscoverStore as any).mockReturnValue({
+      ...mockStore,
+      selectedProspect: mockStore.prospects[0],
+    });
+    render(<ARDiscoveryPage />);
+    const saveButton = screen.getByText('Save Prospect');
+    fireEvent.click(saveButton);
+    expect(mockStore.addToSaved).toHaveBeenCalledWith(mockStore.prospects[0]);
+  });
+
+  it('calls exportProspects when export button is clicked', () => {
+    (useARDiscoverStore as any).mockReturnValue({
+        ...mockStore,
+        savedProspects: [mockStore.prospects[0]],
+      });
+    render(<ARDiscoveryPage />);
+    const exportButton = screen.getByText('Export List (1)');
+    fireEvent.click(exportButton);
+    expect(mockStore.exportProspects).toHaveBeenCalled();
+  });
+});

--- a/src/pages/ARDiscoveryPage.tsx
+++ b/src/pages/ARDiscoveryPage.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect } from 'react';
+import ResultsGrid from '../components/specific/ResultsGrid';
+import PreviewPanel from '../components/specific/PreviewPanel';
+import { useARDiscoverStore } from '../store/arDiscoverStore';
+
+const ARDiscoveryPage: React.FC = () => {
+  const {
+    filters,
+    prospects,
+    savedProspects,
+    selectedProspect,
+    loading,
+    setFilters,
+    searchProspects,
+    exportProspects,
+    selectProspect,
+    addToSaved,
+  } = useARDiscoverStore();
+
+  useEffect(() => {
+    searchProspects();
+  }, [searchProspects]);
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilters({ [e.target.name]: e.target.value });
+  };
+
+  const handleApplyFilters = () => {
+    searchProspects();
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">A&R Discovery</h1>
+      <div className="bg-light-surface dark:bg-dark-surface p-4 rounded-lg shadow-md mb-4">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="text-lg font-semibold">Filters</h2>
+          <button
+            onClick={exportProspects}
+            className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-400"
+            disabled={savedProspects.length === 0}
+          >
+            Export List ({savedProspects.length})
+          </button>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label htmlFor="growth" className="block text-sm font-medium text-light-text-secondary dark:text-dark-text-secondary">
+              Growth Rate
+            </label>
+            <input
+              type="text"
+              name="growth"
+              id="growth"
+              value={filters.growth}
+              onChange={handleFilterChange}
+              className="mt-1 block w-full px-3 py-2 bg-light-background dark:bg-dark-background border border-light-divider dark:border-dark-divider rounded-md shadow-sm focus:outline-none focus:ring-accent-primary focus:border-accent-primary sm:text-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor="saves" className="block text-sm font-medium text-light-text-secondary dark:text-dark-text-secondary">
+              Saves
+            </label>
+            <input
+              type="text"
+              name="saves"
+              id="saves"
+              value={filters.saves}
+              onChange={handleFilterChange}
+              className="mt-1 block w-full px-3 py-2 bg-light-background dark:bg-dark-background border border-light-divider dark:border-dark-divider rounded-md shadow-sm focus:outline-none focus:ring-accent-primary focus:border-accent-primary sm:text-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor="shares" className="block text-sm font-medium text-light-text-secondary dark:text-dark-text-secondary">
+              Shares
+            </label>
+            <input
+              type="text"
+              name="shares"
+              id="shares"
+              value={filters.shares}
+              onChange={handleFilterChange}
+              className="mt-1 block w-full px-3 py-2 bg-light-background dark:bg-dark-background border border-light-divider dark:border-dark-divider rounded-md shadow-sm focus:outline-none focus:ring-accent-primary focus:border-accent-primary sm:text-sm"
+            />
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={handleApplyFilters}
+            className="px-4 py-2 bg-accent-primary text-white rounded-md hover:bg-accent-primary-dark"
+            disabled={loading}
+          >
+            {loading ? 'Searching...' : 'Apply'}
+          </button>
+        </div>
+      </div>
+      <div className="flex">
+        <div className={`w-full ${selectedProspect ? 'md:w-2/3' : 'md:w-full'} transition-all duration-300`}>
+          {loading && prospects.length === 0 ? (
+            <p>Loading prospects...</p>
+          ) : (
+            <ResultsGrid prospects={prospects} onSelectProspect={selectProspect} />
+          )}
+        </div>
+        <PreviewPanel prospect={selectedProspect} onClose={() => selectProspect(null)} onSave={addToSaved} />
+      </div>
+    </div>
+  );
+};
+
+export default ARDiscoveryPage;

--- a/src/store/arDiscoverStore.ts
+++ b/src/store/arDiscoverStore.ts
@@ -1,0 +1,82 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import {
+  searchProspects as searchProspectsApi,
+  saveProspects as saveProspectsApi,
+  exportProspects as exportProspectsApi,
+  getHighlight as getHighlightApi,
+  ARFilters,
+} from '../utils/backend';
+import { Prospect } from '../components/specific/ResultsGrid';
+import { trackEvent } from '../utils/analytics';
+
+
+interface ARDiscoverState {
+  filters: ARFilters;
+  prospects: Prospect[];
+  savedProspects: Prospect[];
+  selectedProspect: Prospect | null;
+  loading: boolean;
+  highlightUrl: string | null;
+  setFilters: (filters: Partial<ARFilters>) => void;
+  searchProspects: () => Promise<void>;
+  saveProspects: () => Promise<void>;
+  exportProspects: () => Promise<void>;
+  selectProspect: (prospect: Prospect | null) => void;
+  getHighlight: (trackId: string) => Promise<void>;
+  addToSaved: (prospect: Prospect) => void;
+}
+
+export const useARDiscoverStore = create<ARDiscoverState>()(
+  devtools((set, get) => ({
+    filters: { growth: '', saves: '', shares: '' },
+    prospects: [],
+    savedProspects: [],
+    selectedProspect: null,
+    loading: false,
+    highlightUrl: null,
+    setFilters: (filters) => set((state) => ({ filters: { ...state.filters, ...filters } })),
+    searchProspects: async () => {
+      set({ loading: true });
+      trackEvent('ar_filters_applied', get().filters);
+      const prospects = await searchProspectsApi(get().filters);
+      set({ prospects, loading: false });
+    },
+    saveProspects: async () => {
+      await saveProspectsApi(get().savedProspects);
+    },
+    exportProspects: async () => {
+      if (get().savedProspects.length === 0) {
+        alert('No saved prospects to export.');
+        return;
+      }
+      trackEvent('ar_exported', { count: get().savedProspects.length });
+      const csv = await exportProspectsApi(get().savedProspects);
+      const link = document.createElement('a');
+      link.href = csv;
+      link.setAttribute('download', 'prospects.csv');
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    },
+    selectProspect: (prospect) => {
+      set({ selectedProspect: prospect, highlightUrl: null });
+      if (prospect) {
+        get().getHighlight(prospect.id);
+      }
+    },
+    getHighlight: async (trackId: string) => {
+        set({ loading: true });
+        trackEvent('ar_preview_played', { trackId });
+        const url = await getHighlightApi(trackId);
+        set({ highlightUrl: url, loading: false });
+    },
+    addToSaved: (prospect: Prospect) => {
+        trackEvent('ar_saved', { prospectId: prospect.id });
+        set((state) => ({
+          savedProspects: [...state.savedProspects, prospect],
+          selectedProspect: null,
+        }));
+    }
+  }))
+);

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -2,7 +2,11 @@ type AnalyticsEvent =
   | 'isrc_opened'
   | 'isrc_bulk_assigned'
   | 'isrc_validated'
-  | 'isrc_exported';
+  | 'isrc_exported'
+  | 'ar_filters_applied'
+  | 'ar_preview_played'
+  | 'ar_saved'
+  | 'ar_exported';
 
 interface AnalyticsData {
   [key: string]: any;

--- a/src/utils/backend.ts
+++ b/src/utils/backend.ts
@@ -57,3 +57,54 @@ export const exportRegistry = async (params: ExportRegistryParams): Promise<stri
   await new Promise(resolve => setTimeout(resolve, 500)); // Simulate network delay
   return csvContent;
 };
+
+// A&R Discovery Mocks
+export interface Prospect {
+  id: string;
+  artistName: string;
+  trackTitle: string;
+  imageUrl: string;
+  reasons: string[];
+}
+
+export interface ARFilters {
+    growth: string;
+    saves: string;
+    shares: string;
+}
+
+export const searchProspects = async (filters: ARFilters): Promise<Prospect[]> => {
+    console.log('Searching prospects with filters:', filters);
+    // Simulate filtering logic
+    await new Promise(resolve => setTimeout(resolve, 500));
+    const mockProspects: Prospect[] = [
+      { id: '1', artistName: 'Ethereal Echo', trackTitle: 'Crystal Caves', imageUrl: 'https://picsum.photos/seed/a/400/400', reasons: ['High Growth', 'Viral'] },
+      { id: '2', artistName: 'Midnight Bloom', trackTitle: 'Neon Petals', imageUrl: 'https://picsum.photos/seed/b/400/400', reasons: ['High Saves'] },
+      { id: '3', artistName: 'Solar Flare', trackTitle: 'Sunspot', imageUrl: 'https://picsum.photos/seed/c/400/400', reasons: ['High Shares', 'New Artist'] },
+      { id: '4', artistName: 'Tidal Wave', trackTitle: 'Deep Blue', imageUrl: 'https://picsum.photos/seed/d/400/400', reasons: ['High Growth'] },
+    ];
+    return mockProspects.filter(p => (filters.growth ? p.reasons.includes('High Growth') : true) && (filters.saves ? p.reasons.includes('High Saves') : true) && (filters.shares ? p.reasons.includes('High Shares') : true));
+};
+
+export const getHighlight = async (trackId: string): Promise<string> => {
+    console.log('Getting highlight for track:', trackId);
+    await new Promise(resolve => setTimeout(resolve, 500));
+    return "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3";
+};
+
+export const saveProspects = async (prospects: Prospect[]): Promise<void> => {
+    console.log('Saving prospects:', prospects);
+    await new Promise(resolve => setTimeout(resolve, 500));
+};
+
+export const exportProspects = async (prospects: Prospect[]): Promise<string> => {
+    console.log('Exporting prospects');
+    const csvContent = [
+      ['Artist Name', 'Track Title', 'Reasons'],
+      ...prospects.map(p => [p.artistName, p.trackTitle, `"${p.reasons.join(', ')}"`]),
+    ]
+      .map(e => e.join(','))
+      .join('\n');
+    await new Promise(resolve => setTimeout(resolve, 500));
+    return 'data:text/csv;charset=utf-8,' + encodeURIComponent(csvContent);
+};


### PR DESCRIPTION
This commit introduces the new A&R Discovery feature, which allows you to surface promising creators using engagement and growth signals.

- Adds a new page at /ar/discover with a state machine for filtering, viewing results, previewing tracks, and saving prospects.
- Implements a flexible UI with filters, a results grid, a side preview panel, and the ability to export saved prospects to a CSV file.
- Integrates a Zustand store for state management, following a 'demo-to-production' approach with a mocked backend that can be easily swapped for a live one.
- Includes analytics events for key user interactions: ar_filters_applied, ar_preview_played, ar_saved, and ar_exported.
- Adds comprehensive unit tests for the new components and functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "A&R Discovery" page accessible from the main navigation, featuring a prospect discovery workflow.
  * Added a responsive grid to browse artist prospects with filtering options for growth rate, saves, and shares.
  * Implemented a preview panel for detailed prospect information, audio highlights, and note-taking.
  * Enabled saving and exporting of selected prospects.

* **Bug Fixes**
  * Not applicable.

* **Tests**
  * Added comprehensive tests covering filtering, selection, preview, saving, and exporting functionalities for the A&R Discovery page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->